### PR TITLE
updated the url

### DIFF
--- a/registration/password_reset_email.html
+++ b/registration/password_reset_email.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% blocktrans %}Reset password at {{ site_name }}{% endblocktrans %}:
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uidb36=uid, token=token %}
+{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
 {% endblock %}


### PR DESCRIPTION
the template raises a `Could not parse the remainder: ',' from 'uid,'` with the uid. 

Updating it to, fixed it.

```
  {{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
```

![password_reset](https://f.cloud.github.com/assets/1097043/793990/19f3dc70-ec5c-11e2-9909-098b4fd51033.png)
